### PR TITLE
Add Browser Sync for HTML hot reload :zap:

### DIFF
--- a/final-project/package.json
+++ b/final-project/package.json
@@ -9,6 +9,8 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-preset-es2015": "^6.24.1",
+    "browser-sync": "^2.26.3",
+    "browser-sync-webpack-plugin": "^2.2.2",
     "css-loader": "^0.28.11",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "^4.8.3",

--- a/final-project/webpack.config.js
+++ b/final-project/webpack.config.js
@@ -1,5 +1,6 @@
 var MiniCssExtractPlugin = require("mini-css-extract-plugin");
 var path = require("path");
+var BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 
 module.exports = {
   entry: "./scripts/main.js",
@@ -11,6 +12,24 @@ module.exports = {
   plugins: [
     new MiniCssExtractPlugin({
       filename: "styles.css"
+    }),
+    new BrowserSyncPlugin({
+      host: 'localhost',
+      port: 3000,
+      proxy: 'http://localhost:8080/',
+      files: [{
+        match: [
+          '**/*.html'
+        ],
+        fn: function(event, file) {
+          if (event === "change") {
+            const bs = require('browser-sync').get('bs-webpack-plugin');
+            bs.reload();
+          }
+        }
+      }]
+    }, {
+      reload: false
     })
   ],
   module: {


### PR DESCRIPTION
Adding Browser Sync for faster development.
It watches only the changes in `.html` files. Also, it has a cool feature as it provides an external URL which you can test your work on different devices (Mobile, Tablet, etc.) with hot reload as well.